### PR TITLE
The response content for tracking is "The event was successfully tracked...

### DIFF
--- a/src/FACTFinder/Adapter/ScicTracking.php
+++ b/src/FACTFinder/Adapter/ScicTracking.php
@@ -272,6 +272,6 @@ class ScicTracking extends AbstractAdapter
      */
     public function applyTracking() {
         $success = trim($this->getResponseContent());
-        return $success == 'true';
+        return $success == 'The event was successfully tracked';
     }
 }


### PR DESCRIPTION
..." instead of "true"
