### PR TITLE
The Util\Parameters cannot contain a value that is an array

### DIFF
--- a/src/FACTFinder/Core/Client/RequestParser.php
+++ b/src/FACTFinder/Core/Client/RequestParser.php
@@ -104,7 +104,18 @@ class RequestParser
                     'Util\Parameters',
                     $_SERVER['QUERY_STRING']
                 );
-                $parameters->setAll($_POST);
+
+                $data = $_POST;
+
+                if (!empty($data)) {
+                    foreach ($data as $key => $value) {
+                        if (is_array($value)) {
+                            unset($data[$key]);
+                        }
+                    }
+                }
+
+                $parameters->setAll($data);
             }
             else if (isset($_GET))
             {


### PR DESCRIPTION
InvalidArgumentException in Parameters.php line 208: Value must not be an array of arrays.
