### PR TITLE
ADDED the Infinity string bug replacement

### DIFF
--- a/src/FACTFinder/Adapter/AbstractAdapter.php
+++ b/src/FACTFinder/Adapter/AbstractAdapter.php
@@ -89,6 +89,11 @@ abstract class AbstractAdapter
     protected function useJsonResponseContentProcessor()
     {
         $this->responseContentProcessor = function($string) {
+
+            if (strpos($string, 'Infinity') !== false) {
+                $string = str_replace('Infinity', '"0"', $string);
+            }
+
             // The second parameter turns objects into associative arrays.
             // stdClass objects don't really have any advantages over plain
             // arrays but miss out on some of the built-in array functions.


### PR DESCRIPTION
Sometimes factfinder returns a json string with an inifinity string represenation ("Infinity"). This causes a Exception, which can be caught but the data itself is OK. So replace simple INF with 0.
