### PR TITLE
Added check to getField if the key isset to prevent Notice: Undefined index

### DIFF
--- a/src/FACTFinder/Data/Record.php
+++ b/src/FACTFinder/Data/Record.php
@@ -102,7 +102,7 @@ class Record
      */
     public function getField($name)
     {
-        return $this->fields[$name];
+        return isset($this->fields[$name]) ? $this->fields[$name] : null;
     }
 
     /**


### PR DESCRIPTION
This check is needed because there is no way to check if a field exists.