### PR TITLE
Fixes unit tests with missing encodingConverter argument

### DIFF
--- a/tests/Adapter/CompareTest.php
+++ b/tests/Adapter/CompareTest.php
@@ -27,7 +27,8 @@ class CompareTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
     }
 

--- a/tests/Adapter/ImportTest.php
+++ b/tests/Adapter/ImportTest.php
@@ -27,7 +27,8 @@ class ImportTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
     }
 

--- a/tests/Adapter/ProductCampaignTest.php
+++ b/tests/Adapter/ProductCampaignTest.php
@@ -27,7 +27,8 @@ class ProductCampaignTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
 
     }

--- a/tests/Adapter/RecommendationTest.php
+++ b/tests/Adapter/RecommendationTest.php
@@ -27,7 +27,8 @@ class RecommendationTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
     }
 

--- a/tests/Adapter/ScicTrackingTest.php
+++ b/tests/Adapter/ScicTrackingTest.php
@@ -30,7 +30,8 @@ class ScicTrackingTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
     }
 

--- a/tests/Adapter/SearchTest.php
+++ b/tests/Adapter/SearchTest.php
@@ -31,7 +31,8 @@ class SearchTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
     }
 

--- a/tests/Adapter/SimilarRecordsTest.php
+++ b/tests/Adapter/SimilarRecordsTest.php
@@ -27,7 +27,8 @@ class SimilarRecordsTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
     }
 

--- a/tests/Adapter/SuggestTest.php
+++ b/tests/Adapter/SuggestTest.php
@@ -31,7 +31,8 @@ class SuggestTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
     }
 

--- a/tests/Adapter/TagCloudTest.php
+++ b/tests/Adapter/TagCloudTest.php
@@ -30,7 +30,8 @@ class TagCloudTest extends \FACTFinder\Test\BaseTestCase
             self::$dic['loggerClass'],
             self::$dic['configuration'],
             self::$dic['request'],
-            self::$dic['clientUrlBuilder']
+            self::$dic['clientUrlBuilder'],
+            self::$dic['encodingConverter']
         );
     }
 


### PR DESCRIPTION
Unit tests were failing because of the missing `encodingConverter` argument