### PR TITLE
FIXED the infi loop for converting empty array

### DIFF
--- a/src/FACTFinder/Core/AbstractEncodingConverter.php
+++ b/src/FACTFinder/Core/AbstractEncodingConverter.php
@@ -60,10 +60,17 @@ abstract class AbstractEncodingConverter
     {
         if (FF::isInstanceOf($data, 'Util\Parameters'))
         {
-            $result = FF::getInstance(
-                'Util\Parameters',
-                $this->convert($inCharset, $outCharset, $data->getArray())
-            );
+            if (count($data->getArray()) == 1 && current(array_keys($data->getArray())) == '')
+            {
+                $result = $data;
+            }
+            else
+            {
+                $result = FF::getInstance(
+                    'Util\Parameters',
+                    $this->convert($inCharset, $outCharset, $data->getArray())
+                );
+            }
         }
         else if (is_array($data))
         {

--- a/src/FACTFinder/Core/AbstractEncodingConverter.php
+++ b/src/FACTFinder/Core/AbstractEncodingConverter.php
@@ -58,11 +58,11 @@ abstract class AbstractEncodingConverter
      */
     protected function convert($inCharset, $outCharset, $data)
     {
-        if (FF::isInstanceOf($data, 'Util\Parameters'))
+        if ($data instanceof Parameters)
         {
             if (count($data->getArray()) == 1 && current(array_keys($data->getArray())) == '')
             {
-                $result = $data;
+                $result = $data->getArray();
             }
             else
             {

--- a/src/FACTFinder/Loader.php
+++ b/src/FACTFinder/Loader.php
@@ -125,6 +125,7 @@ class Loader
         {
             return self::$classNames[$name];
         }
+        $orig = $name;
 
         $name = trim(preg_replace('/^FACTFinder\\\\/i', '', $name));
 
@@ -141,7 +142,7 @@ class Loader
             $className = $defaultClassName;
         else
             throw new \Exception("class '$factfinderClassName' not found");
-        return self::$classNames[$name] = $className;
+        return self::$classNames[$orig] = $className;
     }
 
     /**

--- a/src/FACTFinder/Loader.php
+++ b/src/FACTFinder/Loader.php
@@ -84,15 +84,7 @@ class Loader
      */
     public static function getInstance($name)
     {
-        if (isset(self::$classNames[$name]))
-        {
-            $className = self::$classNames[$name];
-        }
-        else
-        {
-            $className = self::getClassName($name);
-            self::$classNames[$name] = $className;
-        }
+        $className = self::getClassName($name);
 
         // this snippet is from the typo3 class "t3lib_div"
         // written by Kasper Skaarhoj <kasperYYYY@typo3.com>
@@ -129,6 +121,11 @@ class Loader
      */
     public static function getClassName($name)
     {
+        if (isset(self::$classNames[$name]))
+        {
+            return self::$classNames[$name];
+        }
+
         $name = trim(preg_replace('/^FACTFinder\\\\/i', '', $name));
 
         // check whether there is a custom or lib-unrelated class
@@ -144,7 +141,7 @@ class Loader
             $className = $defaultClassName;
         else
             throw new \Exception("class '$factfinderClassName' not found");
-        return $className;
+        return self::$classNames[$name] = $className;
     }
 
     /**


### PR DESCRIPTION
Hi everybody,

We found a Inifinity Loop in the convert method. We got the following as $data:
```
FACTFinder\Util\Parameters Object
(
    [parameters:protected] => Array
        (
            [] =>
        )

)
```

If you call the getInstance for the Parameters and convert the "$data->getArray()" to a Parameter, you get the example above; again and again.
```
Array
(
    [] =>
)
```

We found this by using webgrind, because there were over 69000 calls:
![bildschirmfoto 2015-01-29 um 17 09 42](https://cloud.githubusercontent.com/assets/1152783/5960985/acd7f456-a7d9-11e4-86cf-8cb0f294094b.png)

I don't know, where the empty parameter key is set, but this request just fix this phenomen.

Greetz