### PR TITLE
log error and stacktrace

### DIFF
--- a/src/FACTFinder/Adapter/AbstractAdapter.php
+++ b/src/FACTFinder/Adapter/AbstractAdapter.php
@@ -104,6 +104,12 @@ abstract class AbstractAdapter
                     "json_decode() raised an error: ".json_last_error()
                 );
 
+            if(is_array($jsonData) && isset($jsonData['error'])) {
+                $this->log->error("FACT-Finder returned error: " . strip_tags($jsonData['error']));
+                if(isset($jsonData['stacktrace'])) {
+                    $this->log->error("Stacktrace:\n" . $jsonData['stacktrace']);
+                }
+            }
             return $jsonData;
         };
     }
@@ -113,7 +119,14 @@ abstract class AbstractAdapter
         $this->responseContentProcessor = function($string) {
             libxml_use_internal_errors(true);
             // The constructor throws an exception on error
-            return new \SimpleXMLElement($string);
+            $response = new \SimpleXMLElement($string);
+            if(isset($response->error)) {
+                $this->log->error("FACT-Finder returned error: " . strip_tags($response->error));
+                if(isset($response->stacktrace)) {
+                    $this->log->error("Stacktrace:\n" . $response->stacktrace);
+                }
+            }
+            return $response;
         };
     }
 


### PR DESCRIPTION
If response contains error (stacktrace), log those to errorlog.
This is only available when using XmlResponseContentProcessor or JsonResponseContentProcessor.