### PR TITLE
Development

### DIFF
--- a/src/FACTFinder/Adapter/Search.php
+++ b/src/FACTFinder/Adapter/Search.php
@@ -955,12 +955,12 @@ class Search extends AbstractAdapter
     /**
      * Value for parameter "followSearch" for followups on initial search like filters, pagination, ...
      * Either from request parameters or from search results "simiFirstRecord".
-     * Returns 0 if no valid value for followSearch exists.
+     * Default is 10000.
+     * 
      * @return int
      */
     public function getFollowSearchValue()
     {
-        
         $searchParameters = FF::getInstance(
             'Data\SearchParameters',
             $this->parameters
@@ -974,9 +974,9 @@ class Search extends AbstractAdapter
             $jsonData = $this->getResponseContent();
             if($jsonData && $jsonData['searchResult'] && isset($jsonData['searchResult']['simiFirstRecord']))
                 $followSearch = $jsonData['searchResult']['simiFirstRecord'];
-        // mark as no followSearch
+        // fallback to 10000 as FF6.10 requires it
         } else {
-            $followSearch = 0;
+            $followSearch = 10000;
         }
         return $followSearch;
     }

--- a/src/FACTFinder/Adapter/Search.php
+++ b/src/FACTFinder/Adapter/Search.php
@@ -954,29 +954,40 @@ class Search extends AbstractAdapter
     
     /**
      * Value for parameter "followSearch" for followups on initial search like filters, pagination, ...
-     * Either from request parameters or from search results "simiFirstRecord".
-     * Default is 10000.
+     * Either from search results searchParams, request parameters or from search results "simiFirstRecord".
+     * Returns 0 if no parameter "followSearch" could be acquired.
      * 
      * @return int
      */
     public function getFollowSearchValue()
     {
+        $jsonData = $this->getResponseContent();
+        //use searchParams of result if available
+        if($jsonData && $jsonData['searchResult'] && isset($jsonData['searchResult']['searchParams'])) {
+            $parameters = FF::getInstance(
+                'Util\Parameters',
+                $jsonData['searchResult']['searchParams']
+            );
+        //fallback to current request
+        } else {
+            $parameters = $this->parameters;
+        }
         $searchParameters = FF::getInstance(
             'Data\SearchParameters',
-            $this->parameters
+            $parameters
         );
         $sorting = $searchParameters->getSortings();
-        // check if followSearch was set in request data
-        if($searchParameters->getFollowSearch() !== 10000) {
+        // check if followSearch was set in request data or sent by FF in result searchParams
+        if($searchParameters->getFollowSearch() !== 0) {
             $followSearch =  $searchParameters->getFollowSearch();
         // use simiFirstRecord only if result was not sorted
         } elseif (empty($sorting)) {
             $jsonData = $this->getResponseContent();
             if($jsonData && $jsonData['searchResult'] && isset($jsonData['searchResult']['simiFirstRecord']))
                 $followSearch = $jsonData['searchResult']['simiFirstRecord'];
-        // fallback to 10000 as FF6.10 requires it
+        //mark as not valid
         } else {
-            $followSearch = 10000;
+            $followSearch = 0;
         }
         return $followSearch;
     }

--- a/src/FACTFinder/Data/SearchParameters.php
+++ b/src/FACTFinder/Data/SearchParameters.php
@@ -58,7 +58,7 @@ class SearchParameters
                                  : 1;
         $this->followSearch    = isset($parameters['followSearch'])
                                  ? $parameters['followSearch']
-                                 : 10000;
+                                 : 0;
 
         $this->navigationEnabled = (isset($parameters['catalog']) && $parameters['catalog'] == 'true')
                                    || (isset($parameters['navigation']) && $parameters['navigation'] == 'true');

--- a/tests/Data/SearchParametersTest.php
+++ b/tests/Data/SearchParametersTest.php
@@ -28,6 +28,7 @@ class SearchParametersTest extends \FACTFinder\Test\BaseTestCase
         $parameters['filterColor'] = 'green';
         $parameters['sortPrice'] = 'asc';
         $parameters['catalog'] = 'true';
+        $parameters['followSearch'] = '9832';
 
         $searchParameters = FF::getInstance(
             'Data\SearchParameters',
@@ -39,7 +40,7 @@ class SearchParametersTest extends \FACTFinder\Test\BaseTestCase
         $this->assertEquals('2-_0_0', $searchParameters->getAdvisorStatus());
         $this->assertEquals(12, $searchParameters->getProductsPerPage());
         $this->assertEquals(1, $searchParameters->getCurrentPage());
-        $this->assertEquals(10000, $searchParameters->getFollowSearch());
+        $this->assertEquals(9832, $searchParameters->getFollowSearch());
 
         $this->assertEquals(array('Brand' => 'KHE', 'Color' => 'green'),
                             $searchParameters->getFilters());

--- a/tests/resources/config.xml
+++ b/tests/resources/config.xml
@@ -89,6 +89,7 @@
 				<!-- allow similar/recommandation parameters -->
 				<whitelist name="maxRecordCount" />
 				<whitelist name="maxResults" />
+				<whitelist name="mainId" />
 				<!-- allow special test cases -->
 				<whitelist name="a" />
 				<whitelist name="c" />


### PR DESCRIPTION
Added missing whitelist param "mainId" to test config.xml and fallback for Adapter Search::getFollowSearchValue() to 10000 as FF6.10 requires it.