### PR TITLE
Fallback for createSliderFilter if regEx fails

### DIFF
--- a/src/FACTFinder/Adapter/Search.php
+++ b/src/FACTFinder/Adapter/Search.php
@@ -451,8 +451,15 @@ class Search extends AbstractAdapter
             $matches
         );
 
-        $query = $matches[1] . $matches[3];
-        $fieldName = $matches[2];
+        if(!empty($matches)) {
+         $query = $matches[1] . $matches[3];
+            $fieldName = $matches[2];
+        } else {
+            // The URL of searchParams was not as expected, propably the current filter was not
+            // added as an empty parameter. Therefore no need to remove it and we can use full searchParams URL.
+            $query = $filterData['searchParams'];
+            $fieldName = $filterData['associatedFieldName'];
+        }
 
         if (urldecode($fieldName) != $filterData['associatedFieldName'])
             $this->log->warn('Filter parameter of slider does not correspond '


### PR DESCRIPTION
Under some circumstances FACT-Finder does not include the empty Parameter inside the searchParams URL of slider filters.
Then the currently used regex does not match and the URL of the filter is set to an empty string.
This commit fixes this and falls back to full searchParams URL, if the used regex does not match anything.