### PR TITLE
New ArrayConfiguration class, which takes an array

### DIFF
--- a/src/FACTFinder/Core/ArrayConfiguration.php
+++ b/src/FACTFinder/Core/ArrayConfiguration.php
@@ -1,0 +1,318 @@
+<?php
+namespace FACTFinder\Core;
+
+/**
+ * Implements ConfigurationInterface by reading from a given array
+ */
+class ArrayConfiguration extends AbstractConfiguration
+{
+    const HTTP_AUTHENTICATION     = 'http';
+    const SIMPLE_AUTHENTICATION   = 'simple';
+    const ADVANCED_AUTHENTICATION = 'advanced';
+
+    /**
+     * @var array the configuration.
+     */
+    private $configuration;
+
+    private $clientMappings;
+    private $serverMappings;
+    private $ignoredClientParameters;
+    private $ignoredServerParameters;
+    private $whitelistClientParameters;
+    private $whitelistServerParameters;
+    private $requiredClientParameters;
+    private $requiredServerParameters;
+
+    /**
+     * Create a new configuration from an array
+     * @param array $config The configuration data as array
+     * @return ArrayConfiguration
+     */
+    public function __construct(array $config)
+    {
+        $this->configuration = $config;
+    }
+
+    public function isDebugEnabled()
+    {
+        return $this->configuration['debug'] === true;
+    }
+
+    public function getCustomValue($name)
+    {
+        return $this->configuration[$name];
+    }
+
+    public function getRequestProtocol()
+    {
+        return $this->configuration['connection']['protocol'];
+    }
+
+    public function getServerAddress()
+    {
+        return $this->configuration['connection']['address'];
+    }
+
+    public function getServerPort()
+    {
+        return $this->configuration['connection']['port'];
+    }
+
+    public function getContext()
+    {
+        return $this->configuration['connection']['context'];
+    }
+
+    public function getChannel()
+    {
+        return $this->configuration['connection']['channel'];
+    }
+
+    public function getLanguage()
+    {
+        return $this->configuration['connection']['language'];
+    }
+
+    public function isHttpAuthenticationType()
+    {
+        return $this->retrieveAuthenticationType() === self::HTTP_AUTHENTICATION;
+    }
+
+    public function isSimpleAuthenticationType()
+    {
+        return $this->retrieveAuthenticationType() === self::SIMPLE_AUTHENTICATION;
+    }
+
+    public function isAdvancedAuthenticationType()
+    {
+        return $this->retrieveAuthenticationType() === self::ADVANCED_AUTHENTICATION;
+    }
+
+    private function retrieveAuthenticationType()
+    {
+        return strtolower($this->configuration['connection']['authentication']['type']);
+    }
+
+    public function makeHttpAuthenticationType()
+    {
+        $this->configuration['connection']['authentication']['type'] = self::HTTP_AUTHENTICATION;
+    }
+
+    public function makeSimpleAuthenticationType()
+    {
+        $this->configuration['connection']['authentication']['type'] = self::SIMPLE_AUTHENTICATION;
+    }
+
+    public function makeAdvancedAuthenticationType()
+    {
+        $this->configuration['connection']['authentication']['type'] = self::ADVANCED_AUTHENTICATION;
+    }
+
+    public function getUserName()
+    {
+        return $this->configuration['connection']['authentication']['username'];
+    }
+
+    public function getPassword()
+    {
+        return $this->configuration['connection']['authentication']['password'];
+    }
+
+    public function getAuthenticationPrefix()
+    {
+        return $this->configuration['connection']['authentication']['prefix'];
+    }
+
+    public function getAuthenticationPostfix()
+    {
+        return $this->configuration['connection']['authentication']['postfix'];
+    }
+
+    public function getClientMappings()
+    {
+        if ($this->clientMappings == null) {
+            $this->clientMappings = $this->retrieveMappings($this->configuration['parameters']['client']);
+        }
+        return $this->clientMappings;
+    }
+
+    public function getServerMappings()
+    {
+        if ($this->serverMappings == null) {
+            $this->serverMappings = $this->retrieveMappings($this->configuration['parameters']['server']);
+        }
+        return $this->serverMappings;
+    }
+
+    private function retrieveMappings($section)
+    {
+        $mappings = array();
+        if (isset($section['mapping']) && is_array($section['mapping'])) {
+            //load mappings
+            foreach($section['mapping'] as $rule) {
+                $mappings[$rule['from']] = $rule['to'];
+            }
+        }
+        return $mappings;
+    }
+
+    public function getIgnoredClientParameters()
+    {
+        if ($this->ignoredClientParameters == null) {
+            $this->ignoredClientParameters = $this->retrieveIgnoredParameters(
+                $this->configuration['parameters']['client']
+            );
+        }
+        return $this->ignoredClientParameters;
+    }
+
+    public function getIgnoredServerParameters()
+    {
+        if ($this->ignoredServerParameters == null) {
+            $this->ignoredServerParameters = $this->retrieveIgnoredParameters(
+                $this->configuration['parameters']['server']
+            );
+        }
+        return $this->ignoredServerParameters;
+    }
+
+    private function retrieveIgnoredParameters($section)
+    {
+        $ignoredParameters = array();
+        if (isset($section['ignore']) && is_array($section['ignore'])) {
+            //load ignore rules
+            foreach($section['ignore'] as $name) {
+                $ignoredParameters[$name] = true;
+            }
+        }
+        return $ignoredParameters;
+    }
+
+    public function getWhitelistClientParameters()
+    {
+        if ($this->whitelistClientParameters == null) {
+            $this->whitelistClientParameters = $this->retrieveWhitelistParameters(
+                $this->configuration['parameters']['client']
+            );
+        }
+        return $this->whitelistClientParameters;
+    }
+
+    public function getWhitelistServerParameters()
+    {
+        if ($this->whitelistServerParameters == null) {
+            $this->whitelistServerParameters = $this->retrieveWhitelistParameters(
+                $this->configuration['parameters']['server']
+            );
+            if (empty($this->whitelistServerParameters)) {
+                $this->whitelistServerParameters = parent::getWhitelistServerParameters();
+            }
+        }
+        return $this->whitelistServerParameters;
+    }
+
+    private function retrieveWhitelistParameters($section)
+    {
+        $whitelist = array();
+        if (isset($section['whitelist']) && is_array($section['whitelist'])) {
+            //load whitelist
+            foreach($section['whitelist'] as $name) {
+                $whitelist[$name] = true;
+            }
+        }
+        return $whitelist;
+    }
+
+    public function getRequiredClientParameters()
+    {
+        if ($this->requiredClientParameters == null) {
+            $this->requiredClientParameters = $this->retrieveRequiredParameters(
+                $this->configuration['parameters']['client']
+            );
+        }
+        return $this->requiredClientParameters;
+    }
+
+    public function getRequiredServerParameters()
+    {
+        if ($this->requiredServerParameters == null) {
+            $this->requiredServerParameters = $this->retrieveRequiredParameters(
+                $this->configuration['parameters']['server']
+            );
+        }
+        return $this->requiredServerParameters;
+    }
+
+    private function retrieveRequiredParameters($section)
+    {
+        $requiredParameters = array();
+        if (isset($section['require']) && is_array($section['require'])) {
+            //load require rules
+            foreach($section['require'] as $rule) {
+                $requiredParameters[$rule['name']] = $rule['default'];
+            }
+        }
+        return $requiredParameters;
+    }
+
+    public function getDefaultConnectTimeout()
+    {
+        return $this->configuration['connection']['timeouts']['defaultConnectTimeout'];
+    }
+
+    public function getDefaultTimeout()
+    {
+        return $this->configuration['connection']['timeouts']['defaultTimeout'];
+    }
+
+    public function getSuggestConnectTimeout()
+    {
+        return $this->configuration['connection']['timeouts']['suggestConnectTimeout'];
+    }
+
+    public function getSuggestTimeout()
+    {
+        return $this->configuration['connection']['timeouts']['suggestTimeout'];
+    }
+
+    public function getTrackingConnectTimeout()
+    {
+        return $this->configuration['connection']['timeouts']['trackingConnectTimeout'];
+    }
+
+    public function getTrackingTimeout()
+    {
+        return $this->configuration['connection']['timeouts']['trackingTimeout'];
+    }
+
+    public function getImportConnectTimeout()
+    {
+        return $this->configuration['connection']['timeouts']['importConnectTimeout'];
+    }
+
+    public function getImportTimeout()
+    {
+        return $this->configuration['connection']['timeouts']['importTimeout'];
+    }
+
+    public function getPageContentEncoding()
+    {
+        return $this->configuration['encoding']['pageContent'];
+    }
+
+    public function getClientUrlEncoding()
+    {
+        return $this->configuration['encoding']['clientUrl'];
+    }
+
+    public function setPageContentEncoding($encoding)
+    {
+        $this->configuration['encoding']['pageContent'] = $encoding;
+    }
+
+    public function setClientUrlEncoding($encoding)
+    {
+        $this->configuration['encoding']['clientUrl'] = $encoding;
+    }
+}

--- a/src/FACTFinder/Core/ArrayConfiguration.php
+++ b/src/FACTFinder/Core/ArrayConfiguration.php
@@ -27,11 +27,17 @@ class ArrayConfiguration extends AbstractConfiguration
     /**
      * Create a new configuration from an array
      * @param array $config The configuration data as array
+     * @param string $section The configuration section
      * @return ArrayConfiguration
+     *
+     * @throws \Exception
      */
-    public function __construct(array $config)
+    public function __construct(array $config, $section)
     {
-        $this->configuration = $config;
+        if (!isset($config[$section]))
+            throw new \Exception("Specified configuration array does not contain section $section");
+
+        $this->configuration = $config[$section];
     }
 
     public function isDebugEnabled()

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -26,13 +26,24 @@ class BaseTestCase extends \PHPUnit_Framework_TestCase
 
         self::$dic['loggerClass'] = $logClass;
 
-        self::$dic['configuration'] = function($c) {
-            return FF::getInstance(
-                'Core\XmlConfiguration',
-                RESOURCES_DIR.DS.'config.xml',
-                'test'
-            );
-        };
+        if (strpos(static::class, 'ArrayConfiguration')) {
+            self::$dic['configuration'] = function($c) {
+                $config = include RESOURCES_DIR.DS.'config.php';
+                return FF::getInstance(
+                    'Core\ArrayConfiguration',
+                    $config,
+                    'test'
+                );
+            };
+        } else {
+            self::$dic['configuration'] = function ($c) {
+                return FF::getInstance(
+                    'Core\XmlConfiguration',
+                    RESOURCES_DIR . DS . 'config.xml',
+                    'test'
+                );
+            };
+        }
 
         // $this cannot be passed into closures before PHP 5.4
         //$that = $this;

--- a/tests/Core/ArrayConfigurationTest.php
+++ b/tests/Core/ArrayConfigurationTest.php
@@ -1,0 +1,155 @@
+<?php
+namespace FACTFinder\Test\Core;
+
+use FACTFinder\Loader as FF;
+
+class ArrayConfigurationTest extends \FACTFinder\Test\BaseTestCase
+{
+    /**
+     * @var \FACTFinder\Util\LoggerInterface
+     */
+    private $log;
+
+    /**
+     * @var \FACTFinder\Core\ArrayConfiguration the configuration under test
+     */
+    private $configuration;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $loggerClass = self::$dic['loggerClass'];
+        $this->log = $loggerClass::getLogger(__CLASS__);
+
+        $this->configuration = self::$dic['configuration'];
+    }
+
+    public function testTopLevelSettings()
+    {
+        $this->assertTrue($this->configuration->isDebugEnabled());
+        $this->assertEquals('php-value', $this->configuration->getCustomValue('custom'));
+    }
+
+    public function testConnectionSettings()
+    {
+        $this->assertEquals('http', $this->configuration->getRequestProtocol());
+        $this->assertEquals('demoshop.fact-finder.de', $this->configuration->getServerAddress());
+        $this->assertEquals(80, $this->configuration->getServerPort());
+        $this->assertEquals('FACT-Finder', $this->configuration->getContext());
+        $this->assertEquals('de', $this->configuration->getChannel());
+        $this->assertEquals('de', $this->configuration->getLanguage());
+
+        $this->assertTrue($this->configuration->isAdvancedAuthenticationType());
+        $this->assertFalse($this->configuration->isSimpleAuthenticationType());
+        $this->assertFalse($this->configuration->isHttpAuthenticationType());
+        $this->assertEquals('user', $this->configuration->getUserName());
+        $this->assertEquals('userpw', $this->configuration->getPassword());
+        $this->assertEquals('FACT-FINDER', $this->configuration->getAuthenticationPrefix());
+        $this->assertEquals('FACT-FINDER', $this->configuration->getAuthenticationPostfix());
+
+        $this->assertEquals(2,   $this->configuration->getDefaultConnectTimeout());
+        $this->assertEquals(4,   $this->configuration->getDefaultTimeout());
+        $this->assertEquals(1,   $this->configuration->getSuggestConnectTimeout());
+        $this->assertEquals(2,   $this->configuration->getSuggestTimeout());
+        $this->assertEquals(1,   $this->configuration->getTrackingConnectTimeout());
+        $this->assertEquals(2,   $this->configuration->getTrackingTimeout());
+        $this->assertEquals(10,  $this->configuration->getImportConnectTimeout());
+        $this->assertEquals(360, $this->configuration->getImportTimeout());
+    }
+
+    public function testParameterSettings()
+    {
+        $expectedIgnoredServerParameters = array(
+            'password' => true,
+            'username' => true,
+            'timestamp' => true
+        );
+
+        $this->assertEquals($expectedIgnoredServerParameters, $this->configuration->getIgnoredServerParameters());
+
+        $expectedIgnoredClientParameters = array(
+            'xml' => true,
+            'format' => true,
+            'channel' => true,
+            'password' => true,
+            'username' => true,
+            'timestamp' => true
+        );
+
+        $this->assertEquals($expectedIgnoredClientParameters, $this->configuration->getIgnoredClientParameters());
+
+        $expectedRequiredServerParameters = array();
+
+        $this->assertEquals($expectedRequiredServerParameters, $this->configuration->getRequiredServerParameters());
+
+        $expectedRequiredClientParameters = array();
+
+        $this->assertEquals($expectedRequiredClientParameters, $this->configuration->getRequiredClientParameters());
+
+        $expectedServerMappings = array(
+            'keywords' => 'query'
+        );
+
+        $this->assertEquals($expectedServerMappings, $this->configuration->getServerMappings());
+
+        $expectedClientMappings = array(
+            'query' => 'keywords'
+        );
+
+        $this->assertEquals($expectedClientMappings, $this->configuration->getClientMappings());
+
+        $expectedServerWhitelist = array(
+            'query' => true,
+            '/^filter.*/' => true,
+            'followSearch' => true
+        );
+        
+        $this->assertArraySubset($expectedServerWhitelist, $this->configuration->getWhitelistServerParameters());
+        
+        $expectedClientWhitelist = array(
+            'keywords' => true,
+            '/^filter.*/' => true,
+            'followSearch' => true
+        );
+        
+        $this->assertArraySubset($expectedClientWhitelist, $this->configuration->getWhitelistClientParameters());
+    }
+
+    public function testEncodingSettings()
+    {
+        $this->assertEquals('UTF-8', $this->configuration->getPageContentEncoding());
+        $this->assertEquals('ISO-8859-1', $this->configuration->getClientUrlEncoding());
+    }
+
+    public function testSetAuthenticationType()
+    {
+        $this->assertTrue($this->configuration->isAdvancedAuthenticationType());
+        $this->assertFalse($this->configuration->isSimpleAuthenticationType());
+        $this->assertFalse($this->configuration->isHttpAuthenticationType());
+
+        $this->configuration->makeSimpleAuthenticationType();
+        $this->assertFalse($this->configuration->isAdvancedAuthenticationType());
+        $this->assertTrue($this->configuration->isSimpleAuthenticationType());
+        $this->assertFalse($this->configuration->isHttpAuthenticationType());
+
+        $this->configuration->makeHttpAuthenticationType();
+        $this->assertFalse($this->configuration->isAdvancedAuthenticationType());
+        $this->assertFalse($this->configuration->isSimpleAuthenticationType());
+        $this->assertTrue($this->configuration->isHttpAuthenticationType());
+
+        $this->configuration->makeAdvancedAuthenticationType();
+        $this->assertTrue($this->configuration->isAdvancedAuthenticationType());
+        $this->assertFalse($this->configuration->isSimpleAuthenticationType());
+        $this->assertFalse($this->configuration->isHttpAuthenticationType());
+    }
+
+    public function testSetEncodings()
+    {
+        $this->configuration->setPageContentEncoding('ISO-8859-1');
+        $this->configuration->setClientUrlEncoding('ISO-8859-15');
+
+        $this->assertEquals('ISO-8859-1', $this->configuration->getPageContentEncoding());
+        $this->assertEquals('ISO-8859-15', $this->configuration->getClientUrlEncoding());
+    }
+}

--- a/tests/resources/config.php
+++ b/tests/resources/config.php
@@ -1,0 +1,157 @@
+<?php
+
+return array(
+    'test' => array(
+        'debug' => true,
+        'custom' => 'php-value',
+        'connection' => array(
+            'protocol' => 'http', // possible values: http, https
+            'address' => 'demoshop.fact-finder.de',
+            'port' => 80,
+            'context' => 'FACT-Finder',
+            'channel' => 'de',
+            'language' => 'de',
+            'authentication' => array(
+                'type' => 'advanced', // possible values: http, simple, advanced
+                'username' => 'user',
+                'password' => 'userpw',
+                'prefix' => 'FACT-FINDER',
+                'postfix' => 'FACT-FINDER',
+            ),
+            // all timeouts given in seconds
+            'timeouts' => array(
+                'defaultConnectTimeout' => 2,
+                'defaultTimeout' => 4,
+                'suggestConnectTimeout' => 1,
+                'suggestTimeout' => 2,
+                'trackingConnectTimeout' => 1,
+                'trackingTimeout' => 2,
+                'importConnectTimeout' => 10,
+                'importTimeout' => 360,
+            ),
+        ),
+        'parameters' => array(
+            // parameter settings for the server
+            'server' => array(
+                'ignore' => array(
+                    'password',
+                    'username',
+                    'timestamp',
+                ),
+                'whitelist' => array(
+                    // no whitelist elements means allow everything
+                    // allow search parameters
+                    'query',
+                    'followSearch',
+                    'advisorStatus',
+                    '/^filter.*/',
+                    '/^sort.*/',
+                    'productsPerPage',
+                    'navigation',
+                    'catalog',
+                    'page',
+                    'useKeywords',
+                    'useFoundWords',
+                    'searchField',
+                    'omitContextName',
+                    'productNumber',
+                    'useSemanticEnhancer',
+                    'usePersonalization',
+                    // allow general settings parameters
+                    'channel',
+                    'format',
+                    'idsOnly',
+                    'useAsn',
+                    'useCampaigns',
+                    'verbose',
+                    'log',
+                    'do',
+                    'callback',
+                    // allow suggestions parameters
+                    'ignoreForCache',
+                    'userInput',
+                    'queryFromSuggest',
+                    // allow tracking parameters
+                    'id',
+                    'pos',
+                    'sid',
+                    'origPos',
+                    'page',
+                    'simi',
+                    'title',
+                    'event',
+                    'pageSize',
+                    'origPageSize',
+                    'userId',
+                    'cookieId',
+                    'masterId',
+                    'count',
+                    'price',
+                    // allow similar/recommandation parameters
+                    'maxRecordCount',
+                    'maxResults',
+                    'mainId',
+                    // allow special test cases
+                    'a',
+                    'c',
+                    'ä',
+                    'ü',
+                    '+ ~',
+                ),
+                'mapping' => array(
+                    array('from' => 'keywords', 'to' => 'query'),
+                ),
+            ),
+            // parameter settings for the client
+            'client' => array(
+                'ignore' => array(
+                    'xml',
+                    'format',
+                    'channel',
+                    'password',
+                    'username',
+                    'timestamp'
+                ),
+                'whitelist' => array(
+                    // no whitelist elements means allow everything
+                    // allow search parameters
+                    'keywords',
+                    'followSearch',
+                    'advisorStatus',
+                    '/^filter.*/',
+                    'seoPath',
+                    'productsPerPage',
+                    'navigation',
+                    'catalog',
+                    'page',
+                    'useKeywords',
+                    'useFoundWords',
+                    'searchField',
+                    'omitContextName',
+                    'productNumber',
+                    'useSemanticEnhancer',
+                    'usePersonalization',
+                    // allow general settings parameters
+                    'idsOnly',
+                    'useAsn',
+                    'useCampaigns',
+                    'verbose',
+                    'log',
+                    // allow suggestions parameters
+                    'ignoreForCache',
+                    'userInput',
+                    'queryFromSuggest',
+                    // allow special test cases
+                    'foo',
+                ),
+                'mapping' => array(
+                    array('from' => 'query', 'to' => 'keywords'),
+                ),
+            ),
+        ),
+        'encoding' => array(
+            'pageContent' => 'UTF-8',
+            'clientUrl' => 'ISO-8859-1',
+        ),
+    ),
+);


### PR DESCRIPTION
This is a sibling of XmlConfiguration, which takes an array as parameter to read its configuration from.

Example use in initializer.php of the demo shop project:
`$dic['configuration'] = function($c) {`
`    $config = include USERDATA_DIR.DS.'config.php';`
`    return FF::getInstance(`
`        'Core\ArrayConfiguration',`
`        $config`
`    );`
`};`

This comes in very handy when you want to use the FACT-Finder library in a Zend Framework 2 context, where everything is configured using arrays.
This way you can have the main config value in a factfinder.config.php and your local changes (like another channel) in a factfinder.config.local.php.