### PR TITLE
changed hasSelectedItems() to work on a copy of the filter

### DIFF
--- a/src/FACTFinder/Data/FilterGroup.php
+++ b/src/FACTFinder/Data/FilterGroup.php
@@ -148,7 +148,7 @@ class FilterGroup extends \ArrayIterator
      */
     public function hasSelectedItems()
     {
-        foreach ($this as $filter)
+        foreach ($this->getArrayCopy() as $filter)
             if ($filter->isSelected())
                 return true;
 


### PR DESCRIPTION
Since $this is an ArrayIterator, a foreach will cause the current object pointer to be reset and iterated to the end. This can have unintended side-effects for external calls using "hasSelectedItems" within an iteration over the group (the filter items), since it will only reveal the first item.