### PR TITLE
fix misused private

### DIFF
--- a/src/FACTFinder/Core/AbstractEncodingConverter.php
+++ b/src/FACTFinder/Core/AbstractEncodingConverter.php
@@ -20,7 +20,7 @@ abstract class AbstractEncodingConverter
     /**
      * @var FACTFinder\Util\LoggerInterface
      */
-    private $log;
+    protected $log;
 
     /**
      * @var string


### PR DESCRIPTION
- Solves issue #59
- Description
sets the `$log` property to `protected` instead of `private`.
