### PR TITLE
FIX: XSS

### DIFF
--- a/src/FACTFinder/Util/Parameters.php
+++ b/src/FACTFinder/Util/Parameters.php
@@ -64,7 +64,7 @@ class Parameters implements \ArrayAccess, \Countable
 
             // Use urldecode() because in the QUERY_STRING space is replaced by '+' (http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1)
             $k = urldecode($pair[0]);
-            $v = urldecode($pair[1]);
+            $v = strip_tags(urldecode($pair[1]));
 
             // TODO: This does not currently pay attention to potential array
             //       keys in the parameter name and simply appends the value


### PR DESCRIPTION
It es possible to name html tags in the query parameter. On this way xss attacks are possible. If you, for example, have a query like this

query=">trolo<i>pwnd<img+src%3Dy+onerror%3Dprompt('openbugbounty')>

a foreign js script will be executed when the search is finished.

- Solves issue #
- Description

### Please note that the source and target branch must be "development" (details: https://github.com/FACT-Finder/FACT-Finder-PHP-Library/wiki/Guide-for-contributors).
